### PR TITLE
fix: handle 429 rate limiting with exponential backoff

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11,6 +11,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var lastRefresh: Date?
     private var lastUsage: UsageResponse?
     private var usageServer: UsageServer?
+    private var consecutiveErrors: Int = 0
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Hide dock icon
@@ -72,11 +73,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let result = await api.fetchUsage()
         await MainActor.run {
             self.currentState = result
-            if case .loaded(let usage) = result {
+            switch result {
+            case .loaded(let usage):
                 self.lastUsage = usage
                 self.lastRefresh = Date()
+                self.consecutiveErrors = 0
                 // Feed cache to embedded server
                 self.usageServer?.updateCache(usage)
+            case .error:
+                self.consecutiveErrors += 1
+            case .rateLimited:
+                self.consecutiveErrors += 1
+            default:
+                break
             }
             self.updateMenuBarText()
             self.updatePopoverContent()
@@ -84,14 +93,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Speed up refresh when in error state, slow down when healthy
+    /// Adjust refresh rate: back off on errors/429, normal pace when healthy
     private func adjustRefreshRate(for state: UsageState) {
         let interval: TimeInterval
         switch state {
         case .loaded:
             interval = 300  // 5 min when healthy
-        case .authNeeded, .noAuth, .error, .noCDP:
-            interval = 30   // 30s when errored — auto-recover faster
+        case .rateLimited(let retryAfter):
+            // Respect server's Retry-After, minimum 60s, max 10 min
+            interval = min(max(retryAfter, 60), 600)
+        case .error:
+            // Exponential backoff: 60s, 120s, 240s, 480s, capped at 600s
+            let backoff = 60.0 * pow(2.0, Double(min(consecutiveErrors - 1, 3)))
+            interval = min(backoff, 600)
+        case .authNeeded, .noAuth, .noCDP:
+            interval = 120  // Auth issues: check every 2 min (user may re-auth)
         case .loading:
             return
         }
@@ -127,6 +143,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 .font: NSFont.monospacedSystemFont(ofSize: 12, weight: .medium)
             ]
             button.attributedTitle = NSAttributedString(string: "⚡\(session)% 📅\(weekly)%", attributes: attrs)
+        case .rateLimited:
+            button.title = "⏳ 429"
         case .error:
             button.title = "⚠️ Error"
         case .authNeeded:

--- a/Sources/PopoverView.swift
+++ b/Sources/PopoverView.swift
@@ -47,6 +47,9 @@ struct PopoverView: View {
                 }
             case .loaded(let usage):
                 usageContent(usage)
+            case .rateLimited(let retryAfter):
+                Label("Rate limited — retrying in \(Int(retryAfter))s", systemImage: "hourglass")
+                    .foregroundColor(.orange)
             case .error(let msg):
                 Label(msg, systemImage: "exclamationmark.triangle.fill")
                     .foregroundColor(.orange)

--- a/Sources/UsageAPI.swift
+++ b/Sources/UsageAPI.swift
@@ -141,6 +141,11 @@ class UsageAPI {
                     }
                     return .authNeeded
                 }
+                if httpResponse.statusCode == 429 {
+                    let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After")
+                        .flatMap { Double($0) } ?? 60
+                    return .rateLimited(retryAfter: retryAfter)
+                }
                 if httpResponse.statusCode != 200 {
                     return .error("HTTP \(httpResponse.statusCode)")
                 }

--- a/Sources/UsageModel.swift
+++ b/Sources/UsageModel.swift
@@ -63,6 +63,7 @@ enum UsageState {
     case loading
     case loaded(UsageResponse)
     case error(String)
+    case rateLimited(retryAfter: TimeInterval)  // 429 — back off
     case authNeeded   // Token expired
     case noAuth       // No credentials found
     case noCDP        // Legacy — kept for compatibility but unused in OAuth mode


### PR DESCRIPTION
## Problem

When the app receives a 429 (rate limited) from the Anthropic API, it treats it as a generic error and **speeds up** the refresh interval from 5min to 30s. This creates a death spiral: more 429s → faster retries → more 429s.

## Changes

- **New `.rateLimited` state** — distinguishes 429 from other errors
- **Reads `Retry-After` header** — respects the server-requested delay (default 60s if missing)
- **Exponential backoff for errors** — 60s → 120s → 240s → 480s → 600s cap (was fixed 30s)
- **Auth errors at 120s** — moderate pace for user to re-auth (was 30s)
- **Consecutive error counter** — resets on successful fetch
- **UI updates** — menu bar shows ⏳ 429, popover shows retry countdown

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| 429 rate limited | 30s retry (death spiral) | Respect Retry-After, min 60s |
| Generic error | 30s retry | Exponential backoff 60s–600s |
| Auth expired | 30s retry | 120s retry |
| Healthy | 5min | 5min (unchanged) |