### PR TITLE
fix: add OAuth token auto-refresh and failure protection

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11,7 +11,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var lastRefresh: Date?
     private var lastUsage: UsageResponse?
     private var usageServer: UsageServer?
-    private var consecutiveErrors: Int = 0
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Hide dock icon
@@ -77,15 +76,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             case .loaded(let usage):
                 self.lastUsage = usage
                 self.lastRefresh = Date()
-                self.consecutiveErrors = 0
                 // Persist snapshot for history/heatmap
                 UsageStore.shared.record(usage)
                 // Feed cache to embedded server
                 self.usageServer?.updateCache(usage)
-            case .error:
-                self.consecutiveErrors += 1
-            case .rateLimited:
-                self.consecutiveErrors += 1
             default:
                 break
             }
@@ -95,24 +89,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// Adjust refresh rate: back off on errors/429, normal pace when healthy
+    /// Adjust refresh rate — delegates interval decision to FailureGate (single source of truth)
     private func adjustRefreshRate(for state: UsageState) {
-        let interval: TimeInterval
-        switch state {
-        case .loaded:
-            interval = 300  // 5 min when healthy
-        case .rateLimited(let retryAfter):
-            // Respect server's Retry-After, minimum 60s, max 10 min
-            interval = min(max(retryAfter, 60), 600)
-        case .error:
-            // Exponential backoff: 60s, 120s, 240s, 480s, capped at 600s
-            let backoff = 60.0 * pow(2.0, Double(min(consecutiveErrors - 1, 3)))
-            interval = min(backoff, 600)
-        case .authNeeded, .noAuth, .noCDP:
-            interval = 120  // Auth issues: check every 2 min (user may re-auth)
-        case .loading:
-            return
-        }
+        if case .loading = state { return }
+        let interval = api.gate.suggestedInterval
 
         if let timer = refreshTimer, timer.timeInterval == interval { return }
         refreshTimer?.invalidate()

--- a/Sources/OAuthManager.swift
+++ b/Sources/OAuthManager.swift
@@ -16,25 +16,46 @@ class OAuthManager {
         }
     }
 
-    /// Read OAuth access token. Priority: CLIProxyAPI (auto-refreshing) > Keychain > file
-    func getAccessToken() throws -> String {
+    private var cachedToken: String?
+    private var cacheExpiry: Date?
+
+    /// Read OAuth access token. Priority: CLIProxyAPI > Memory cache > Keychain > File > Refresh
+    func getAccessToken() async throws -> String {
         // 1. CLIProxyAPI — has refresh_token, auto-renews
         if let token = readFromCLIProxyAPI() {
             return token
         }
 
-        // 2. Keychain (Claude Code CLI)
+        // 2. Memory cache
+        if let token = cachedToken, let expiry = cacheExpiry, expiry > Date() {
+            return token
+        }
+
+        // 3. Keychain (Claude Code CLI) — valid (not expired) access token
         if let token = readFromKeychain() {
             return token
         }
 
-        // 3. Fallback: ~/.claude/.credentials.json
+        // 4. File — valid (not expired) access token
         if let token = readFromFile() {
             return token
         }
 
+        // 5. Try refresh using refreshToken from keychain or file
+        if let refreshToken = readRefreshTokenFromKeychain() ?? readRefreshTokenFromFile() {
+            return try await refreshAccessToken(refreshToken: refreshToken)
+        }
+
         throw OAuthError.noCredentials
     }
+
+    /// Invalidate memory cache — call on 401 before retrying so refresh is attempted
+    func invalidateCache() {
+        cachedToken = nil
+        cacheExpiry = nil
+    }
+
+    // MARK: - Token sources
 
     /// Read from ~/.cli-proxy-api/claude-*.json (CLIProxyAPI with auto-refresh)
     private func readFromCLIProxyAPI() -> String? {
@@ -107,7 +128,85 @@ class OAuthManager {
             return nil
         }
 
+        // Check expiry
+        if let expiresAt = oauth["expiresAt"] as? Double {
+            if Date(timeIntervalSince1970: expiresAt / 1000) < Date() {
+                return nil  // Expired, fall through to refresh
+            }
+        }
+
         return token
     }
-}
 
+    private func readRefreshTokenFromKeychain() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "Claude Code-credentials",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              let refreshToken = oauth["refreshToken"] as? String,
+              !refreshToken.isEmpty else {
+            return nil
+        }
+
+        return refreshToken
+    }
+
+    private func readRefreshTokenFromFile() -> String? {
+        let path = NSString(string: "~/.claude/.credentials.json").expandingTildeInPath
+        guard let data = FileManager.default.contents(atPath: path),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let oauth = json["claudeAiOauth"] as? [String: Any],
+              let refreshToken = oauth["refreshToken"] as? String,
+              !refreshToken.isEmpty else {
+            return nil
+        }
+
+        return refreshToken
+    }
+
+    // MARK: - Token refresh
+
+    private func refreshAccessToken(refreshToken: String) async throws -> String {
+        let url = URL(string: "https://platform.claude.com/v1/oauth/token")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "grant_type", value: "refresh_token"),
+            URLQueryItem(name: "refresh_token", value: refreshToken),
+            URLQueryItem(name: "client_id", value: "9d1c250a-e61b-44d9-88ed-5944d1962f5e")
+        ]
+        request.httpBody = components.query?.data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw OAuthError.tokenExpired
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accessToken = json["access_token"] as? String,
+              !accessToken.isEmpty else {
+            throw OAuthError.invalidCredentials
+        }
+
+        let expiresIn = json["expires_in"] as? Double ?? 3600
+        cachedToken = accessToken
+        cacheExpiry = Date().addingTimeInterval(expiresIn - 60)  // 1-minute buffer
+
+        return accessToken
+    }
+}

--- a/Sources/UsageAPI.swift
+++ b/Sources/UsageAPI.swift
@@ -1,14 +1,118 @@
 import Foundation
 
+// MARK: - FailureGate
+
+/// Tracks consecutive API failures and suggests retry intervals to prevent hammering.
+class FailureGate {
+    private struct CredentialFingerprint: Equatable {
+        let modificationDate: Date
+        let fileSize: Int
+    }
+
+    private(set) var consecutiveFailures: Int = 0
+    private(set) var isTerminalAuthBlock: Bool = false
+    private var terminalFingerprint: CredentialFingerprint? = nil
+    private(set) var suggestedInterval: TimeInterval = 300
+
+    func recordSuccess() {
+        consecutiveFailures = 0
+        isTerminalAuthBlock = false
+        terminalFingerprint = nil
+        suggestedInterval = 300
+    }
+
+    /// Mark a 401/403 terminal auth failure. Polls every 60s to detect credential changes.
+    func recordAuthFailure() {
+        isTerminalAuthBlock = true
+        terminalFingerprint = currentFingerprint()
+        suggestedInterval = 60
+    }
+
+    /// Respect server's Retry-After, bounded to [60s, 10min].
+    func recordRateLimited(retryAfter: TimeInterval) {
+        suggestedInterval = min(max(retryAfter, 60), 600)
+    }
+
+    /// Increment failure count. Returns true if this error should be suppressed
+    /// (first failure when prior good data exists — treated as a flake).
+    func recordError(hasPriorGoodData: Bool) -> Bool {
+        consecutiveFailures += 1
+        if consecutiveFailures == 1 && hasPriorGoodData {
+            suggestedInterval = 300  // Keep normal pace for first flake
+            return true  // Suppressed
+        }
+        // Exponential backoff: 5min base, doubling each failure after the first surfaced one
+        // failure 2 → 5min, failure 3 → 10min, failure 4 → 20min ... cap at 6h
+        let doublings = max(consecutiveFailures - 2, 0)
+        suggestedInterval = min(300.0 * pow(2.0, Double(doublings)), 21600)
+        return false
+    }
+
+    /// True if credentials file changed since terminal block was set (user re-authenticated).
+    func credentialsChanged() -> Bool {
+        guard isTerminalAuthBlock else { return false }
+        return currentFingerprint() != terminalFingerprint
+    }
+
+    func clearTerminalBlock() {
+        isTerminalAuthBlock = false
+        terminalFingerprint = nil
+        consecutiveFailures = 0
+        suggestedInterval = 300
+    }
+
+    private func currentFingerprint() -> CredentialFingerprint? {
+        let path = NSString(string: "~/.claude/.credentials.json").expandingTildeInPath
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let modDate = attrs[.modificationDate] as? Date,
+              let fileSize = attrs[.size] as? Int else {
+            return nil
+        }
+        return CredentialFingerprint(modificationDate: modDate, fileSize: fileSize)
+    }
+}
+
+// MARK: - UsageAPI
+
 class UsageAPI {
     private let oauthManager = OAuthManager()
+    let gate = FailureGate()
+    private var lastGoodUsage: UsageResponse?
 
     /// Fetch usage — if remoteURL is set, read from remote cache; otherwise query Anthropic directly.
     func fetchUsage() async -> UsageState {
         if let remoteURL = Self.remoteURL, !remoteURL.isEmpty {
             return await fetchFromRemote(remoteURL)
         }
-        return await doFetch(retried: false)
+
+        // Skip the API call if we're in a terminal auth block and credentials haven't changed
+        if gate.isTerminalAuthBlock {
+            if gate.credentialsChanged() {
+                gate.clearTerminalBlock()
+            } else {
+                return .authNeeded
+            }
+        }
+
+        let result = await doFetch(retried: false)
+
+        switch result {
+        case .loaded(let usage):
+            gate.recordSuccess()
+            lastGoodUsage = usage
+        case .authNeeded:
+            gate.recordAuthFailure()
+        case .rateLimited(let retryAfter):
+            gate.recordRateLimited(retryAfter: retryAfter)
+        case .error:
+            if gate.recordError(hasPriorGoodData: lastGoodUsage != nil), let usage = lastGoodUsage {
+                return .loaded(usage)  // Suppress first flake — return cached data
+            }
+        default:
+            break
+        }
+
+        return result
     }
 
     // MARK: - Remote mode (client)
@@ -120,7 +224,7 @@ class UsageAPI {
 
     private func doFetch(retried: Bool) async -> UsageState {
         do {
-            let token = try oauthManager.getAccessToken()
+            let token = try await oauthManager.getAccessToken()
 
             guard let url = URL(string: "https://api.anthropic.com/api/oauth/usage") else {
                 return .error("Invalid URL")
@@ -135,7 +239,8 @@ class UsageAPI {
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
                     if !retried {
-                        // Token might have been refreshed by Claude CLI in the meantime
+                        // Invalidate cache and retry — OAuthManager will attempt a token refresh
+                        oauthManager.invalidateCache()
                         try? await Task.sleep(nanoseconds: 2_000_000_000)
                         return await doFetch(retried: true)
                     }


### PR DESCRIPTION
## Summary

- **OAuthManager**: `getAccessToken()` is now `async`. Adds an in-memory token cache with expiry, and a full OAuth refresh flow (`POST https://platform.claude.com/v1/oauth/token` with `grant_type=refresh_token`). The refresh token is read from Keychain or `~/.claude/.credentials.json`. Token source priority: CLIProxyAPI → Memory cache → Keychain → File → Refresh. `invalidateCache()` lets callers force re-evaluation on 401.

- **FailureGate** (new class in UsageAPI): owns all retry/backoff logic:
  - Suppresses the first flake when prior good data exists (returns cached success instead of surfacing the error)
  - Exponential backoff for persistent errors: 5 min base, doubling each failure, capped at 6 hours
  - 429: respects `Retry-After` header, clamped to [60s, 10min]
  - 401/403: sets a terminal auth block; unblocks only when the credentials file fingerprint (mtime + size) changes — prevents infinite retry loops on genuinely invalid tokens

- **AppDelegate**: `adjustRefreshRate()` simplified to read `api.gate.suggestedInterval`. Removed duplicate backoff math and the now-redundant `consecutiveErrors` counter.

## Test plan

- [ ] App builds cleanly with `build.sh`
- [ ] Normal usage: menu bar shows usage, refreshes every 5 min
- [ ] Expired access token with valid refresh token: OAuthManager silently refreshes and fetch succeeds
- [ ] Single API error: suppressed (cached data shown, no error state)
- [ ] Repeated API errors: exponential backoff kicks in, error state surfaced after 2nd consecutive failure
- [ ] 429 response: respects Retry-After, max 10 min
- [ ] 401 with no valid credentials: terminal block set; clears after re-login (credentials file changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)