### PR TITLE
[#11] 支持深色模式

### DIFF
--- a/Sources/PopoverView.swift
+++ b/Sources/PopoverView.swift
@@ -160,7 +160,7 @@ struct PopoverView: View {
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
                     RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.gray.opacity(0.2))
+                        .fill(Color.primary.opacity(0.15))
                         .frame(height: 8)
                     RoundedRectangle(cornerRadius: 4)
                         .fill(gradientForUtilization(utilization))

--- a/Sources/StatsView.swift
+++ b/Sources/StatsView.swift
@@ -144,12 +144,8 @@ struct HeatmapSection: View {
     private func heatColor(delta: Double) -> Color {
         guard delta > 0 else { return Color.primary.opacity(0.07) }
         let t = min(delta / maxDelta, 1.0)
-        // Light green → dark green
-        return Color(
-            red:   0.565 - t * 0.49,
-            green: 0.823 - t * 0.43,
-            blue:  0.565 - t * 0.49
-        )
+        // Light green → dark green (semantic, dark mode friendly)
+        return Color.green.opacity(0.2 + t * 0.8)
     }
 
     private func shortDate(_ s: String) -> String {
@@ -372,7 +368,7 @@ struct StatCardsSection: View {
         }
         .padding(8)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.primary.opacity(0.05))
+        .background(Color.primary.opacity(0.08))
         .cornerRadius(8)
     }
 }


### PR DESCRIPTION
## Summary

支持 macOS 深色模式，弹窗 UI 跟随系统外观自动切换。

## Changes

- `PopoverView.swift`: 进度条背景改用语义色 `Color.primary.opacity(0.15)`
- `StatsView.swift`: Heatmap 改用 `Color.green` 系统色梯度
- `StatsView.swift`: 统计卡片背景 opacity 从 0.05 提升到 0.08

## Testing

- 编译通过
- 浅色/深色模式下所有 UI 元素可读

Closes #11