### PR TITLE
[#13] OAuth Failure Gate + Token 持久化

### DIFF
--- a/Sources/OAuthFailureGate.swift
+++ b/Sources/OAuthFailureGate.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Security
+
+/// 双层 OAuth 刷新失败 Gate
+/// - Terminal: invalid_grant 永久阻断，直到 Keychain 凭证变化
+/// - Transient: 429/网络错误，指数退避 5min → 6h max
+class OAuthFailureGate {
+
+    enum BlockStatus {
+        case allowed
+        case terminalBlocked(reason: String)
+        case transientBackoff(until: Date)
+    }
+
+    // UserDefaults keys
+    private static let terminalBlockedKey = "oauthTerminalBlocked"
+    private static let terminalReasonKey = "oauthTerminalReason"
+    private static let transientBlockedUntilKey = "oauthTransientBlockedUntil"
+    private static let transientFailureCountKey = "oauthTransientFailureCount"
+    private static let keychainFingerprintKey = "oauthKeychainFingerprint"
+
+    private static let baseInterval: TimeInterval = 300      // 5 min
+    private static let maxInterval: TimeInterval = 21600     // 6 hours
+
+    /// 检查是否允许刷新
+    static func shouldAttemptRefresh() -> BlockStatus {
+        // Terminal check
+        if UserDefaults.standard.bool(forKey: terminalBlockedKey) {
+            // 检查 keychain fingerprint 是否变了
+            if hasKeychainChanged() {
+                clearAll()
+                return .allowed
+            }
+            let reason = UserDefaults.standard.string(forKey: terminalReasonKey) ?? "invalid_grant"
+            return .terminalBlocked(reason: reason)
+        }
+
+        // Transient check
+        if let blockedUntilRaw = UserDefaults.standard.object(forKey: transientBlockedUntilKey) as? Double {
+            let blockedUntil = Date(timeIntervalSince1970: blockedUntilRaw)
+            if blockedUntil > Date() {
+                // 仍在退避中，但检查 keychain 是否变了
+                if hasKeychainChanged() {
+                    clearAll()
+                    return .allowed
+                }
+                return .transientBackoff(until: blockedUntil)
+            }
+            // 退避已过期，清除
+            clearTransient()
+        }
+
+        return .allowed
+    }
+
+    /// 记录 terminal 失败（invalid_grant / 400）
+    static func recordTerminalFailure(reason: String = "invalid_grant") {
+        UserDefaults.standard.set(true, forKey: terminalBlockedKey)
+        UserDefaults.standard.set(reason, forKey: terminalReasonKey)
+        clearTransient()
+        saveCurrentFingerprint()
+    }
+
+    /// 记录 transient 失败（429、网络错误）
+    static func recordTransientFailure() {
+        // 如果已经 terminal 阻断，不降级
+        guard !UserDefaults.standard.bool(forKey: terminalBlockedKey) else { return }
+
+        let count = UserDefaults.standard.integer(forKey: transientFailureCountKey) + 1
+        UserDefaults.standard.set(count, forKey: transientFailureCountKey)
+
+        let interval = cooldownInterval(failures: count)
+        let blockedUntil = Date().addingTimeInterval(interval)
+        UserDefaults.standard.set(blockedUntil.timeIntervalSince1970, forKey: transientBlockedUntilKey)
+
+        saveCurrentFingerprint()
+    }
+
+    /// 刷新成功，清除所有 gate
+    static func recordSuccess() {
+        clearAll()
+    }
+
+    /// 指数退避: 5min * 2^(n-1), max 6h
+    private static func cooldownInterval(failures: Int) -> TimeInterval {
+        guard failures > 0 else { return 0 }
+        let factor = pow(2.0, Double(failures - 1))
+        return min(baseInterval * factor, maxInterval)
+    }
+
+    private static func clearAll() {
+        UserDefaults.standard.removeObject(forKey: terminalBlockedKey)
+        UserDefaults.standard.removeObject(forKey: terminalReasonKey)
+        clearTransient()
+        UserDefaults.standard.removeObject(forKey: keychainFingerprintKey)
+    }
+
+    private static func clearTransient() {
+        UserDefaults.standard.removeObject(forKey: transientBlockedUntilKey)
+        UserDefaults.standard.removeObject(forKey: transientFailureCountKey)
+    }
+
+    // MARK: - Keychain fingerprint
+
+    private static func saveCurrentFingerprint() {
+        if let fp = currentKeychainFingerprint() {
+            UserDefaults.standard.set(fp, forKey: keychainFingerprintKey)
+        }
+    }
+
+    private static func hasKeychainChanged() -> Bool {
+        guard let saved = UserDefaults.standard.string(forKey: keychainFingerprintKey) else { return false }
+        guard let current = currentKeychainFingerprint() else { return false }
+        return current != saved
+    }
+
+    /// 读取 Keychain 中 Claude Code credentials 的 hash 作为 fingerprint
+    private static func currentKeychainFingerprint() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "Claude Code-credentials",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+
+        // djb2 hash over content — stable across process runs
+        var hash: UInt64 = 5381
+        for byte in data {
+            hash = hash &* 31 &+ UInt64(byte)
+        }
+        return String(hash)
+    }
+}

--- a/Sources/OAuthManager.swift
+++ b/Sources/OAuthManager.swift
@@ -6,12 +6,14 @@ class OAuthManager {
         case noCredentials
         case invalidCredentials
         case tokenExpired
+        case rateLimited
 
         var errorDescription: String? {
             switch self {
             case .noCredentials: return "No Claude Code credentials found — run `claude` CLI and log in"
             case .invalidCredentials: return "Invalid credentials format in Keychain"
             case .tokenExpired: return "OAuth token expired — run `claude` to refresh"
+            case .rateLimited: return "OAuth refresh rate limited — backing off"
             }
         }
     }
@@ -43,7 +45,14 @@ class OAuthManager {
 
         // 5. Try refresh using refreshToken from keychain or file
         if let refreshToken = readRefreshTokenFromKeychain() ?? readRefreshTokenFromFile() {
-            return try await refreshAccessToken(refreshToken: refreshToken)
+            switch OAuthFailureGate.shouldAttemptRefresh() {
+            case .allowed:
+                return try await refreshAccessToken(refreshToken: refreshToken)
+            case .terminalBlocked:
+                throw OAuthError.noCredentials
+            case .transientBackoff:
+                throw OAuthError.rateLimited
+            }
         }
 
         throw OAuthError.noCredentials
@@ -192,21 +201,59 @@ class OAuthManager {
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
-        guard let httpResponse = response as? HTTPURLResponse,
-              httpResponse.statusCode == 200 else {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            OAuthFailureGate.recordTransientFailure()
+            throw OAuthError.tokenExpired
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            break
+        case 400:
+            OAuthFailureGate.recordTerminalFailure(reason: "invalid_grant")
+            throw OAuthError.tokenExpired
+        case 429:
+            OAuthFailureGate.recordTransientFailure()
+            throw OAuthError.rateLimited
+        default:
+            OAuthFailureGate.recordTransientFailure()
             throw OAuthError.tokenExpired
         }
 
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let accessToken = json["access_token"] as? String,
               !accessToken.isEmpty else {
+            OAuthFailureGate.recordTransientFailure()
             throw OAuthError.invalidCredentials
         }
 
         let expiresIn = json["expires_in"] as? Double ?? 3600
+        let newRefreshToken = json["refresh_token"] as? String ?? refreshToken
+
         cachedToken = accessToken
         cacheExpiry = Date().addingTimeInterval(expiresIn - 60)  // 1-minute buffer
 
+        OAuthFailureGate.recordSuccess()
+        persistCredentials(accessToken: accessToken, refreshToken: newRefreshToken, expiresIn: expiresIn)
+
         return accessToken
+    }
+
+    private func persistCredentials(accessToken: String, refreshToken: String, expiresIn: Double) {
+        let path = NSString(string: "~/.claude/.credentials.json").expandingTildeInPath
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+
+        let expiresAt = (Date().timeIntervalSince1970 + expiresIn) * 1000
+        let json: [String: Any] = [
+            "claudeAiOauth": [
+                "accessToken": accessToken,
+                "refreshToken": refreshToken,
+                "expiresAt": expiresAt
+            ]
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) {
+            FileManager.default.createFile(atPath: path, contents: data)
+        }
     }
 }

--- a/Sources/UsageAPI.swift
+++ b/Sources/UsageAPI.swift
@@ -149,6 +149,9 @@ class UsageAPI {
             let decoder = JSONDecoder()
             let usage = try decoder.decode(UsageResponse.self, from: data)
             return .loaded(usage)
+        } catch OAuthManager.OAuthError.rateLimited {
+            // OAuth refresh was rate-limited — back off with a default interval
+            return .rateLimited(retryAfter: 300)
         } catch is OAuthManager.OAuthError {
             return .noAuth
         } catch {


### PR DESCRIPTION
## Summary

借鉴 CodexBar 实现双层 OAuth 失败 Gate + Token 刷新持久化。

## Changes

- **新增** `OAuthFailureGate.swift`: 双层 gate（terminal/transient），指数退避，UserDefaults 持久化，Keychain fingerprint 变化检测
- **改造** `OAuthManager.swift`: 接入 gate，refresh 成功回写文件，区分 400/429 错误
- **适配** `UsageAPI.swift`: 处理新 rateLimited 错误类型

## Testing

- 编译通过（无 warning）
- Terminal failure (400) → 永久阻断直到 Keychain 变化
- Transient failure (429) → 5min/10min/20min 退避
- Refresh 成功 → 写回 ~/.claude/.credentials.json

Closes #13